### PR TITLE
add env.close

### DIFF
--- a/gym_anytrading/envs/trading_env.py
+++ b/gym_anytrading/envs/trading_env.py
@@ -148,6 +148,9 @@ class TradingEnv(gym.Env):
             "Total Reward: %.6f" % self._total_reward + ' ~ ' +
             "Total Profit: %.6f" % self._total_profit
         )
+        
+    def close(self):
+        plt.close()
 
 
     def save_rendering(self, filepath):

--- a/gym_anytrading/envs/trading_env.py
+++ b/gym_anytrading/envs/trading_env.py
@@ -149,6 +149,7 @@ class TradingEnv(gym.Env):
             "Total Profit: %.6f" % self._total_profit
         )
         
+        
     def close(self):
         plt.close()
 


### PR DESCRIPTION
when you run many envs, you have to have a way to close the render windows. env.close() is the standard way to do this in openai gym, so this pull request just adds a simple env.close method to the TradingEnv class, which closes the pyplot window. then you can play atari games and trade stocks in a loop with rendering, and not clutter your screen with too many windows!